### PR TITLE
[CBPS-1783] cm: Support getting node alt addresses from SD

### DIFF
--- a/config-manager/internal/api/handlers.go
+++ b/config-manager/internal/api/handlers.go
@@ -55,12 +55,13 @@ func (h *Handler) CreateSnapshot(w http.ResponseWriter, r *http.Request) {
 	configs := make([]interface{}, len(req.Configs))
 	for i, config := range req.Configs {
 		configs[i] = map[string]interface{}{
-			"hostnames": config.Hostnames,
-			"type":      config.Type,
-			"port":      config.Port,
-			"product":   config.Product,
-			"sd_path":   config.SDPath,
-			"scheme":    config.Scheme,
+			"hostnames":         config.Hostnames,
+			"type":              config.Type,
+			"port":              config.Port,
+			"product":           config.Product,
+			"sd_path":           config.SDPath,
+			"scheme":            config.Scheme,
+			"use_alt_addresses": config.UseAltAddresses,
 		}
 	}
 

--- a/config-manager/internal/models/snapshot.go
+++ b/config-manager/internal/models/snapshot.go
@@ -42,12 +42,13 @@ type SnapshotResponse struct {
 // when Type=="sd" AND Product != "couchbase" (e.g. "/sd/targets"). It must
 // begin with "/" and may include a query string.
 type ConfigObject struct {
-	Hostnames []string `json:"hostnames"`
-	Type      string   `json:"type,omitempty"`
-	Port      int      `json:"port"`
-	Product   string   `json:"product,omitempty"`
-	SDPath    string   `json:"sd_path,omitempty"`
-	Scheme    string   `json:"scheme,omitempty"`
+	Hostnames       []string `json:"hostnames"`
+	Type            string   `json:"type,omitempty"`
+	Port            int      `json:"port"`
+	Product         string   `json:"product,omitempty"`
+	SDPath          string   `json:"sd_path,omitempty"`
+	Scheme          string   `json:"scheme,omitempty"`
+	UseAltAddresses bool     `json:"use_alt_addresses,omitempty"`
 }
 
 // DisplaySnapshot represents the snapshot structure for GET responses or display purposes

--- a/config-manager/internal/products/couchbase.go
+++ b/config-manager/internal/products/couchbase.go
@@ -13,7 +13,7 @@ import (
 var couchbaseProduct = &Product{
 	Name: "couchbase",
 
-	ResolveSDPath: func(scheme string) string {
+	ResolveSDPath: func(scheme string, useAltAddresses bool) string {
 		// Couchbase's SD endpoint returns the same targets regardless of
 		// scheme; only the `port=` parameter changes the per-target port
 		// the SD response advertises (insecure → 8091-style, secure →
@@ -22,7 +22,15 @@ var couchbaseProduct = &Product{
 		if scheme == "https" {
 			portType = "secure"
 		}
-		return fmt.Sprintf("/prometheus_sd_config?port=%s&clusterLabels=uuidAndName", portType)
+		// The `network=` parameter controls whether default or alternate node addresses
+		// are returned as SD targets (default -> default address, external -> alt address)
+		// You would request alt addresses when nodes have private default addresses and public
+		// alt addresses (e.g. in some cloud environments)
+		network := "default"
+		if useAltAddresses {
+			network = "external"
+		}
+		return fmt.Sprintf("/prometheus_sd_config?port=%s&clusterLabels=uuidAndName&network=%s", portType, network)
 	},
 
 	// Couchbase has no notion of a "static" metrics path here — its

--- a/config-manager/internal/products/products.go
+++ b/config-manager/internal/products/products.go
@@ -20,9 +20,10 @@ type Product struct {
 
 	// ResolveSDPath returns the URL path (and optional query string)
 	// that completes a service-discovery URL. The full URL is built as
-	// {scheme}://{host}:{port}{ResolveSDPath(scheme)}. Return "" (or
-	// leave nil) to indicate the product has no default SD path; the
-	// caller must then supply sd_path explicitly when using type=sd.
+	// {scheme}://{host}:{port}{ResolveSDPath(scheme, useAltAddresses)}.
+	// Return "" (or leave nil) to indicate the product has no default
+	// SD path; the caller must then supply sd_path explicitly when
+	// using type=sd.
 	ResolveSDPath func(scheme string, useAltAddresses bool) string
 
 	// DefaultStaticPath is the metrics path the product exposes on its

--- a/config-manager/internal/products/products.go
+++ b/config-manager/internal/products/products.go
@@ -23,7 +23,7 @@ type Product struct {
 	// {scheme}://{host}:{port}{ResolveSDPath(scheme)}. Return "" (or
 	// leave nil) to indicate the product has no default SD path; the
 	// caller must then supply sd_path explicitly when using type=sd.
-	ResolveSDPath func(scheme string) string
+	ResolveSDPath func(scheme string, useAltAddresses bool) string
 
 	// DefaultStaticPath is the metrics path the product exposes on its
 	// static targets (e.g. "/_expvar" for SGW). Recorded for future

--- a/config-manager/internal/storage/file.go
+++ b/config-manager/internal/storage/file.go
@@ -120,6 +120,8 @@ func (fs *FileStorage) generateVMAgentConfig(clusterInfo interface{}, id string)
 		}
 		bucket := bucketFor(configScheme)
 
+		useAltAddresses, _ := config["use_alt_addresses"].(bool)
+
 		switch configType := config["type"].(string); configType {
 		case "sd":
 			product, _ := config["product"].(string)
@@ -130,7 +132,7 @@ func (fs *FileStorage) generateVMAgentConfig(clusterInfo interface{}, id string)
 			path := sdPath
 			if path == "" {
 				if p := products.Get(product); p != nil && p.ResolveSDPath != nil {
-					path = p.ResolveSDPath(configScheme)
+					path = p.ResolveSDPath(configScheme, useAltAddresses)
 				}
 			}
 			for _, hostname := range hostnames {


### PR DESCRIPTION
### Ticket: [CBPS-1783](https://jira.issues.couchbase.com/browse/CBPS-1783)

Couchbase Server's prometheus SD endpoint returns default node hostnames by default, but in some cloud environments this can mean returning private/internal IP addresses instead of publicly accessible ones. This means metrics cannot be scraped from nodes.

If we pass `network=external` query parameter to the SD endpoint then it will return the alternate addresses of nodes. If these are configured to be public addresses, then this will enable successful metric scraping.

This change adds an optional `use_alt_addresses` field in the snapshot payload, which will set `network=external` in the SD path when the product is `couchbase`.

See ticket for testing details.

[CBPS-1783]: https://couchbasecloud.atlassian.net/browse/CBPS-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ